### PR TITLE
do not use frozen content as source

### DIFF
--- a/minify-html.php
+++ b/minify-html.php
@@ -85,8 +85,8 @@ class MinifyHtmlPlugin extends Plugin
   {
     require_once(__DIR__ . '/vendor/autoload.php');
 
-    // HTML input (not compressed)
-    $sourceHtml = $this->grav['output'];
+    // HTML input (not compressed)    
+    $sourceHtml = $this->grav->output;
 
     // Compression mode
     $mode = $this->config['plugins.minify-html.mode'];


### PR DESCRIPTION
If the plugin fetches 

```
$sourceHtml = $this->grav['output'];
```
other plugins have no chance to run in other changes before.

$grav['output'] is read-only (frozen) while $this->grav->output is updateable.